### PR TITLE
Allow "cancel" to stop beauti from closing.

### DIFF
--- a/src/beastfx/app/beauti/BeautiTabPane.java
+++ b/src/beastfx/app/beauti/BeautiTabPane.java
@@ -1350,6 +1350,7 @@ public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane impleme
             // check file needs to be save on closing main frame
             frame.setOnCloseRequest(e-> {
                     if (!beauti.quit()) {
+                        e.consume();
                         return;
                     }
                     Stage frame0 = (Stage) e.getSource();


### PR DESCRIPTION
Attempting to close BEAUti with data loaded results in the following modal:

<img width="472" alt="Screenshot 2023-01-06 at 12 15 28" src="https://user-images.githubusercontent.com/512538/211001750-5549ac71-88d6-41cb-b993-04596a9d9d9a.png">

Selecting "Cancel" should abort the closing procedure, but currently both "Cancel" and "No" seem to behave identically.  The problem is that BEAUti's handler for the close event allows the event to bubble up to a built-in handler which terminates the process, even when "Cancel" is selected.

This PR simply adds a line to BEAUti's handler which prevents the propagation, yielding the expected behaviour.