### PR TITLE
Command line argument handling fix.

### DIFF
--- a/src/beastfx/app/beauti/BeautiTabPane.java
+++ b/src/beastfx/app/beauti/BeautiTabPane.java
@@ -1239,7 +1239,7 @@ public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane impleme
 	        			i++;
 	        		}
 	        	}
-	        	if (args[i].equals("-packagedir")) {
+	        	if (i < args.length-1 && args[i].equals("-packagedir")) {
 	        		args[i] = "";
 	        		i++;
 	                String dir = args[i];


### PR DESCRIPTION
This patch fixes an error in the Beauti command line argument handling code which previously resulted in an array being read past its end when the -version_file argument was provided.