### PR TITLE
Fixed command line argument parsing problem.

### DIFF
--- a/src/beastfx/app/beauti/BeautiTabPane.java
+++ b/src/beastfx/app/beauti/BeautiTabPane.java
@@ -1229,23 +1229,28 @@ public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane impleme
         BeautiDoc doc;
         try {
 			PackageManager.loadExternalJars();
-	        for (int i = 0; i < args.length - 1; i++) {
-	        	if (args[i].equals("-version_file")) {
+            int i=0;
+	        while (i < args.length) {
+	        	if (i < args.length-1 && args[i].equals("-version_file")) {
 	        		args[i] = "";
-	        		i++;
+                    i++;
 	        		while (i < args.length && !args[i].startsWith("-")) {
 	        			BEASTClassLoader.addServices(args[i]);
 		        		args[i] = "";
-	        			i++;
+                        i++;
 	        		}
-	        	}
-	        	if (i < args.length-1 && args[i].equals("-packagedir")) {
+	        	} else if (i < args.length-1 && args[i].equals("-packagedir")) {
 	        		args[i] = "";
 	        		i++;
 	                String dir = args[i];
 	                System.setProperty("beast.user.package.dir", dir);
 	        		args[i] = "";
-	            }
+                    i++;
+	            } else {
+                    Log.warning("Skipping unknown argument " + args[i]);
+                    args[i] = "";
+                    i++;
+                }
 	        }
 			if (Utils.isMac()) {
 			  	Utils.loadUIManager();


### PR DESCRIPTION
This patch addresses another command line argument parsing problem.  Previously, the inner loop used to process 0 or more arguments to -version_file was incrementing the index too many times, causing other arguments to be missed.