### PR TITLE
Bug fix and improvements for BeautiTabPane and BeautiDoc argument parsers

### DIFF
--- a/src/beastfx/app/beauti/BeautiTabPane.java
+++ b/src/beastfx/app/beauti/BeautiTabPane.java
@@ -1246,11 +1246,8 @@ public class BeautiTabPane extends beastfx.app.inputeditor.BeautiTabPane impleme
 	                System.setProperty("beast.user.package.dir", dir);
 	        		args[i] = "";
                     i++;
-	            } else {
-                    Log.warning("Skipping unknown argument " + args[i]);
-                    args[i] = "";
-                    i++;
-                }
+	            }
+                i++;
 	        }
 			if (Utils.isMac()) {
 			  	Utils.loadUIManager();

--- a/src/beastfx/app/inputeditor/BeautiDoc.java
+++ b/src/beastfx/app/inputeditor/BeautiDoc.java
@@ -245,6 +245,19 @@ public class BeautiDoc extends BEASTObject implements RequiredInputProvider {
                     }
                     i += 2;
                     traitset = parser.traitSet;
+                } else if (args[i].startsWith("-fasta_")) {
+                    FastaImporter fastaImporter = new FastaImporter();
+                    if (args[i].equals("-fasta_nucleotide"))
+                        fastaImporter.datatype = FastaImporter.dtype.nucleotide;
+                    else if (args[i].equals("-fasta_aminoacid"))
+                        fastaImporter.datatype = FastaImporter.dtype.aminoacid;
+                    else
+                        throw new IllegalArgumentException("Unknown command line argument " + args[i]);
+                    String fileName = args[i+1];
+                    List<BEASTInterface> results = fastaImporter.loadFile(new File(fileName));
+                    if (results != null && results.size()==1 && results.get(0) instanceof Alignment)
+                        alignments.add((Alignment) results.get(0));
+                    i += 2;
                 } else if (args[i].equals("-xmldata")) {
                     // NB: multiple -xmldata/-nex commands can be processed!
                     String fileName = args[i + 1];


### PR DESCRIPTION
Hi Remco, here is the bugfix I mentioned.

Also, I've snuck in a couple of additional command line arguments "-fasta_nucleotide" and "-fasta_aminoacid" which, like "-nex", let people supply an alignment on the command line.  I find this incredibly helpful when developing beauti templates, as the File->Import alignment step can become very tedious.

If you don't like the look of the extra options, let me know and I'll remove them from the PR.