### PR TITLE
Fixes disappearing parameters when switching between Tree priors

### DIFF
--- a/src/beastfx/app/inputeditor/BeautiSubTemplate.java
+++ b/src/beastfx/app/inputeditor/BeautiSubTemplate.java
@@ -269,6 +269,13 @@ public class BeautiSubTemplate extends BEASTObject {
         for (BeautiConnector connector : template.connectors) {
             doc.disconnect(connector, context);
         }
+        if (template.suppressedInputs.get() != null) {
+            String[] inputs = template.suppressedInputs.get().split(",");
+            for (String input : inputs) {
+                input = input.trim();
+                doc.beautiConfig.suppressBEASTObjects.remove(input);
+            }
+        }
     }
     
     void removeSubNet(Object o)  {


### PR DESCRIPTION
Fixes issue #88.

Not entirely sure if it's the best place in the code to do this, maybe Remco could weigh in? 