### PR TITLE
Graceful exit for Illegal Arguments passed to app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+.idea
+BeastFX.iml
+Build/

--- a/src/beastfx/app/tools/AppLauncher.java
+++ b/src/beastfx/app/tools/AppLauncher.java
@@ -1,14 +1,13 @@
 package beastfx.app.tools;
 
 
-
-
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +18,7 @@ import java.util.TreeSet;
 import javax.swing.*;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import beast.base.core.Log;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -33,8 +33,8 @@ import beast.pkgmgmt.launcher.BeastLauncher;
  * launch applications specific to add-ons installed, for example utilities for
  * post-processing add-on specific data.
  *
- * @author  Remco Bouckaert
- * @author  Walter Xie
+ * @author Remco Bouckaert
+ * @author Walter Xie
  */
 public class AppLauncher {
     public static final String DEFAULT_ICON = "beastfx/app/tools/images/utility.png";
@@ -59,11 +59,11 @@ public class AppLauncher {
         packageComboBox = new JComboBox<>(new String[]{ALL});
         packageComboBox.setToolTipText("Show application of the installed package(s)");
         packageComboBox.addActionListener(e -> {
-                JComboBox<?> cb = (JComboBox<?>) e.getSource();
-                if (cb.getSelectedItem() != null) {
-                    resetAppList(cb.getSelectedItem().toString());
-                }
-            });
+            JComboBox<?> cb = (JComboBox<?>) e.getSource();
+            if (cb.getSelectedItem() != null) {
+                resetAppList(cb.getSelectedItem().toString());
+            }
+        });
         label.setLabelFor(packageComboBox);
         top.add(label);
         top.add(packageComboBox);
@@ -87,22 +87,22 @@ public class AppLauncher {
 
     private Component createList() {
         listApps = new JList<PackageApp>(model) {
- 			private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-			//Subclass JList to workaround bug 4832765, which can cause the
+            //Subclass JList to workaround bug 4832765, which can cause the
             //scroll pane to not let the user easily scroll up to the beginning
             //of the list.  An alternative would be to set the unitIncrement
             //of the JScrollBar to a fixed value. You wouldn't get the nice
             //aligned scrolling, but it should work.
             @Override
-			public int getScrollableUnitIncrement(Rectangle visibleRect,
+            public int getScrollableUnitIncrement(Rectangle visibleRect,
                                                   int orientation,
                                                   int direction) {
                 int row;
                 if (orientation == SwingConstants.VERTICAL &&
                         direction < 0 && (row = getFirstVisibleIndex()) != -1) {
                     Rectangle r = getCellBounds(row, row);
-                    if ((r.y == visibleRect.y) && (row != 0))  {
+                    if ((r.y == visibleRect.y) && (row != 0)) {
                         Point loc = r.getLocation();
                         loc.y--;
                         int prevIndex = locationToIndex(loc);
@@ -120,17 +120,17 @@ public class AppLauncher {
         };
         listApps.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         listApps.setCellRenderer(new DefaultListCellRenderer() {
-			private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-			@Override
+            @Override
             public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
                                                           boolean cellHasFocus) {
                 JLabel label = (JLabel) super
                         .getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 PackageApp app = (PackageApp) value;
-                label.setText(app.description +  " (" + app.packageName + ")");
+                label.setText(app.description + " (" + app.packageName + ")");
                 Image img = app.icon.getImage()
-                        .getScaledInstance(50,50, Image.SCALE_SMOOTH);
+                        .getScaledInstance(50, 50, Image.SCALE_SMOOTH);
                 label.setIcon(new ImageIcon(img));
                 label.setHorizontalTextPosition(SwingConstants.RIGHT);
                 label.setVerticalTextPosition(SwingConstants.CENTER);
@@ -141,7 +141,7 @@ public class AppLauncher {
         listApps.setVisibleRowCount(-1);
         listApps.addMouseListener(new MouseAdapter() {
             @Override
-			public void mouseClicked(MouseEvent e) {
+            public void mouseClicked(MouseEvent e) {
                 if (e.getClickCount() == 2) {
                     launchButton.doClick();
                 }
@@ -203,23 +203,23 @@ public class AppLauncher {
         box.add(Box.createGlue());
 
         launchButton.addActionListener(e -> {
-                PackageApp packageApp = listApps.getSelectedValue();
-                if (packageApp != null) {
-                    try {
-                        new PackageAppThread(packageApp).start();
+            PackageApp packageApp = listApps.getSelectedValue();
+            if (packageApp != null) {
+                try {
+                    new PackageAppThread(packageApp).start();
 
-                    } catch (Exception ex) {
-                        JOptionPane.showMessageDialog(null, "Launch failed because: " + ex.getMessage());
-                    }
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(null, "Launch failed because: " + ex.getMessage());
                 }
-            });
+            }
+        });
         box.add(launchButton);
 
         JButton closeButton = new JButton("Close");
         closeButton.addActionListener(e -> {
 //				setVisible(false);
-                mainDialog.dispose();
-            });
+            mainDialog.dispose();
+        });
         box.add(Box.createGlue());
         box.add(closeButton);
         box.add(Box.createGlue());
@@ -232,14 +232,14 @@ public class AppLauncher {
         for (String jarDirName : dirs) {
             File versionFile = new File(jarDirName + "/version.xml");
             if (versionFile.exists() && versionFile.isFile()) {
-            	getPackageApps(versionFile, packageApps, jarDirName);
+                getPackageApps(versionFile, packageApps, jarDirName);
             }
         }
         return packageApps;
     }
 
     public static void getPackageApps(File versionFile, List<PackageApp> packageApps, String jarDirName) {
-    	
+
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         Document doc;
         try {
@@ -249,7 +249,7 @@ public class AppLauncher {
             Element packageElement = doc.getDocumentElement();
             NodeList nodes = doc.getElementsByTagName("packageapp");
             if (nodes.getLength() == 0) {
-            	nodes = doc.getElementsByTagName("addonapp");
+                nodes = doc.getElementsByTagName("addonapp");
             }
             for (int j = 0; j < nodes.getLength(); j++) {
                 Element packageAppElement = (Element) nodes.item(j);
@@ -273,9 +273,11 @@ public class AppLauncher {
             // ignore
             System.err.println(e.getMessage());
         }
-	}
-    
-    /** thread for launching add on application **/
+    }
+
+    /**
+     * thread for launching add on application
+     **/
     class PackageAppThread extends Thread {
         PackageApp packageApp;
 
@@ -296,92 +298,104 @@ public class AppLauncher {
 
 //              setJavaHeapAndStackSize(cmd, args);
 
-			String classPath = BeastLauncher.getPath(false, null);
-             
+            String classPath = BeastLauncher.getPath(false, null);
+
             PackageManager.loadExternalJars();
-  			for (String jarFile : classPath.split(File.pathSeparator)) {
-  				if (jarFile.toLowerCase().endsWith("jar")) {
-  					BEASTClassLoader.classLoader.addJar(jarFile);
-  				}
-  			}
+            for (String jarFile : classPath.split(File.pathSeparator)) {
+                if (jarFile.toLowerCase().endsWith("jar")) {
+                    BEASTClassLoader.classLoader.addJar(jarFile);
+                }
+            }
 
-  			additionalArgs = processVersionFileArguments(additionalArgs);
-  			
-  			Class<?> mainClass = BEASTClassLoader.forName(packageApp.className, "has.main.method");
-  			Method mainMethod = mainClass.getMethod("main", String [].class);
-System.err.println("About to invoke " + packageApp.className + " " + mainMethod);
-			if (additionalArgs == null) {
-				additionalArgs = new String[] {};
-			}
-System.err.println("Args:" + Arrays.toString(additionalArgs));
-  			mainMethod.invoke(null, (Object) additionalArgs);
-System.err.println("Done invoking " + packageApp.className);
+            additionalArgs = processVersionFileArguments(additionalArgs);
 
-          } catch (Throwable e) {
-              e.printStackTrace();
-          }
+            Class<?> mainClass = BEASTClassLoader.forName(packageApp.className, "has.main.method");
+            Method mainMethod = mainClass.getMethod("main", String[].class);
+            Log.info("About to invoke " + packageApp.className + " " + mainMethod);
+            if (additionalArgs == null) {
+                additionalArgs = new String[]{};
+            }
+            Log.info("Args:" + Arrays.toString(additionalArgs));
+
+            try {
+                mainMethod.invoke(null, (Object) additionalArgs);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof IllegalArgumentException) {
+                    Log.err("\n[Error]: " + cause.getMessage());
+                } else {
+                    Log.err("\n[Unexpected Error]: " + cause.getClass().getSimpleName() + ": " + cause.getMessage());
+                    cause.printStackTrace();
+                }
+            }
+
+            Log.info("Done invoking " + packageApp.className);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
 
     }
-    
-	private String[] processVersionFileArguments(String[] additionalArgs) {
-		// process version file arguments;
-		boolean foundVersionFileArgument = false;
-		for (int i = 0; i < additionalArgs.length; i++) {
-			if (additionalArgs[i].equals("-version_file")) {
-				additionalArgs[i] = "";
-				i++;
-				while (i < additionalArgs.length && !additionalArgs[i].startsWith("-")) {
-					BEASTClassLoader.addServices(additionalArgs[i]);
-					additionalArgs[i] = "";
-					i++;
-					foundVersionFileArgument = true;
-				}
-			}
-		}
-		if (foundVersionFileArgument) {
-			List<String> args = new ArrayList<>();
-			for (String str : additionalArgs) {
-				if (!str.equals("")) {
-					args.add(str);
-				}
-			}
-			additionalArgs = args.toArray(new String[] {});
-		}
-		return additionalArgs;
-	}
+
+    private String[] processVersionFileArguments(String[] additionalArgs) {
+        // process version file arguments;
+        boolean foundVersionFileArgument = false;
+        for (int i = 0; i < additionalArgs.length; i++) {
+            if (additionalArgs[i].equals("-version_file")) {
+                additionalArgs[i] = "";
+                i++;
+                while (i < additionalArgs.length && !additionalArgs[i].startsWith("-")) {
+                    BEASTClassLoader.addServices(additionalArgs[i]);
+                    additionalArgs[i] = "";
+                    i++;
+                    foundVersionFileArgument = true;
+                }
+            }
+        }
+        if (foundVersionFileArgument) {
+            List<String> args = new ArrayList<>();
+            for (String str : additionalArgs) {
+                if (!str.equals("")) {
+                    args.add(str);
+                }
+            }
+            additionalArgs = args.toArray(new String[]{});
+        }
+        return additionalArgs;
+    }
 
 
-	private String sanitise(String property) {
-		// sanitise for windows
-		if (beastfx.app.util.Utils.isWindows()) {
-			String cwd = System.getProperty("user.dir");
-			cwd = cwd.replace("\\", "/");
-			property = property.replaceAll(";\\.", ";" +  cwd + ".");
-			property = property.replace("\\", "/");
-		}
-		return property;
-	}
+    private String sanitise(String property) {
+        // sanitise for windows
+        if (beastfx.app.util.Utils.isWindows()) {
+            String cwd = System.getProperty("user.dir");
+            cwd = cwd.replace("\\", "/");
+            property = property.replaceAll(";\\.", ";" + cwd + ".");
+            property = property.replace("\\", "/");
+        }
+        return property;
+    }
 
     private void printUsage(PrintStream ps) {
         ps.println("\nAppLauncher: Run installed BEAST 2 package apps.\n" +
-                        "\n" +
-                        "Usage:\n" +
-                        "\tapplauncher\n" +
-                        "\tapplauncher -help\n" +
-                        "\tapplauncher -list [package_name]\n" +
-                        "\tapplauncher <app_class_name|app_description>");
+                "\n" +
+                "Usage:\n" +
+                "\tapplauncher\n" +
+                "\tapplauncher -help\n" +
+                "\tapplauncher -list [package_name]\n" +
+                "\tapplauncher <app_class_name|app_description>");
     }
 
     private void printAppList(List<PackageApp> appList, PrintStream ps) {
 
         int maxPNlen = appList.stream().mapToInt(x -> x.packageName.length()).max().orElse(0);
-        maxPNlen = Math.max(maxPNlen+1, 15);
+        maxPNlen = Math.max(maxPNlen + 1, 15);
 
         int maxCNlen = appList.stream().mapToInt(x -> {
             String[] components = x.className.split("\\.");
-            return components[components.length-1].length();
+            return components[components.length - 1].length();
         }).max().orElse(0);
-        maxCNlen = Math.max(maxCNlen+1, 15);
+        maxCNlen = Math.max(maxCNlen + 1, 15);
 
         String formatStr = "%-" + maxPNlen + "." + maxPNlen + "s|%-" + maxCNlen + "." + maxCNlen + "s|%s\n";
 
@@ -390,7 +404,7 @@ System.err.println("Done invoking " + packageApp.className);
 
         for (PackageApp app : appList) {
             String[] fullClassName = app.className.split("\\.");
-            String className = fullClassName[fullClassName.length-1];
+            String className = fullClassName[fullClassName.length - 1];
             ps.format(formatStr, app.packageName, className, app.description);
         }
     }
@@ -399,30 +413,30 @@ System.err.println("Done invoking " + packageApp.className);
         AppLauncher appStore = new AppLauncher();
 
         if (args.length == 0) {
-        	// Utils.loadUIManager();
+            // Utils.loadUIManager();
             try {
-				PackageManager.loadExternalJars();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+                PackageManager.loadExternalJars();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
             SwingUtilities.invokeLater(() -> appStore.launchGUI().setVisible(true));
         } else {
 
             if (args[0].startsWith("-")) {
-                switch(args[0]) {
+                switch (args[0]) {
                     case "-help":
                         appStore.printUsage(System.out);
                         System.exit(0);
 
                     case "-list":
                         try {
-            				PackageManager.loadExternalJars();
-            			} catch (IOException e) {
-            				// TODO Auto-generated catch block
-            				e.printStackTrace();
-            			}
-                        System.out.println("\nAvailable package apps:\n");
-                        if (args.length>1) {
+                            PackageManager.loadExternalJars();
+                        } catch (IOException e) {
+                            // TODO Auto-generated catch block
+                            e.printStackTrace();
+                        }
+                        Log.info("\nAvailable package apps:\n");
+                        if (args.length > 1) {
                             String packageNameFilter = args[1].toLowerCase();
 
                             List<PackageApp> filteredAppList = new ArrayList<>();
@@ -430,22 +444,22 @@ System.err.println("Done invoking " + packageApp.className);
                                 if (!app.packageName.toLowerCase().contains(packageNameFilter))
                                     filteredAppList.add(app);
                             }
-                            appStore.printAppList(filteredAppList, System.out);
+                            appStore.printAppList(filteredAppList, Log.info);
                         } else {
-                            appStore.printAppList(appStore.getPackageApps(), System.out);
+                            appStore.printAppList(appStore.getPackageApps(), Log.info);
                         }
                         System.exit(0);
                     default:
-                        System.err.print("\nUnsupported option.");
-                        appStore.printUsage(System.err);
+                        Log.err("\nUnsupported option.");
+                        appStore.printUsage(Log.err);
                         System.exit(1);
                 }
             } else {
                 try {
-    				PackageManager.loadExternalJars();
-    			} catch (IOException e) {
-    				e.printStackTrace();
-    			}
+                    PackageManager.loadExternalJars();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
 
                 // Find apps with class name or description that matches
                 // command line.
@@ -466,16 +480,16 @@ System.err.println("Done invoking " + packageApp.className);
                 if (exactMatchApp != null)
                     appStore.runAppFromCMD(exactMatchApp, packageArgs);
                 else {
-                    if (partialMatchingApps.size()==1) {
+                    if (partialMatchingApps.size() == 1) {
                         appStore.runAppFromCMD(partialMatchingApps.get(0), packageArgs);
                     } else {
                         if (partialMatchingApps.isEmpty()) {
-                            System.err.println("\nNo apps match.");
-                            appStore.printUsage(System.err);
+                            Log.err.println("\nNo apps match.");
+                            appStore.printUsage(Log.err);
                             System.exit(1);
                         } else {
-                            System.err.println("\nMultiple apps match:\n");
-                            appStore.printAppList(partialMatchingApps, System.err);
+                            Log.err.println("\nMultiple apps match:\n");
+                            appStore.printAppList(partialMatchingApps, Log.err);
                         }
                         System.exit(1);
                     }


### PR DESCRIPTION
Illegal arguments shouldn't print a full stack trace, but simply the help and the unrecognized argument

@rbouckaert Also need to fix: `validateInputs()` not being called in `Application.parseArgs()`