### PR TITLE
Add locallib JavaFX jars to compile classpath

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,6 +37,7 @@
 	<path id="classpath">
 		<fileset dir="${libFX}" includes="jam.jar"/>
 		<fileset dir="${libFX}" includes="testfx.jar"/>
+		<fileset dir="${libFX}" includes="javafx*.jar"/>
         <path location="${buildFX}"/>
 
 		<fileset dir="${beast2path}/lib" includes="beagle.jar"/>


### PR DESCRIPTION
locallib/ ships javafx.base.jar, javafx.controls.jar, javafx.fxml.jar, javafx.graphics.jar, javafx.media.jar, javafx.swing.jar, javafx.web.jar, and javafx-swt.jar, but the compile classpath only pulled in jam.jar, testfx.jar, and assertj-core-3.20.2.jar. Compilation therefore failed with "package javafx.geometry does not exist" (and ~2800 follow-on errors) on any JDK that does not bundle JavaFX — i.e. anything other than the Zulu-FX referenced by the openjre* properties.

This adds one line — `<fileset dir="${libFX}" includes="javafx*.jar"/>` — so a plain JDK (Zulu/Temurin/Oracle, no FX) builds cleanly using the jars already in the repo. `build_jar_all_BeastFX` succeeds end-to-end on Zulu 25 with this change.